### PR TITLE
#5 Menu close when changing on mojave makeshift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,8 @@ dist
 
 # npm lock file
 package-lock.json
+
+# macosx generated file
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/main.js
+++ b/main.js
@@ -218,17 +218,21 @@ const updateMenuInfo = () => {
   menuCurrent.label = `\tCurrent: ${chargerInfo.Current / 1000}A`;
 };
 
-const notify = (oldChargerInfo) => {
-  if (!menuChangeNotification.checked) {
-    return;
-  }
-
-  if (
+const isChanged = (oldChargerInfo) => {
+  if(
     oldChargerInfo
     && oldChargerInfo.Watts == chargerInfo.Watts
     && oldChargerInfo.Voltage == chargerInfo.Voltage
     && oldChargerInfo.Current == chargerInfo.Current
   ) {
+    return false;
+  }
+
+  return true;
+};
+
+const notify = () => {
+  if (!menuChangeNotification.checked) {
     return;
   }
 
@@ -252,8 +256,11 @@ const update = () => {
 
   updateAppIcon();
   updateAppIconTitle();
+  if (!isChanged(oldChargerInfo)) {
+    return;
+  }
   updateMenuInfo();
-  notify(oldChargerInfo);
+  notify();
 
   updateMenu();
 };


### PR DESCRIPTION
環境により再現しないとのことでしたので、もう少し手を動かしてみました。

macosx Mojaveの本家Tray電源状態表示機能は、Menu表示中は状況が変化しても表示内容を更新しない。
- MojaveではOSレベルで動的変更はできないor難しいのかも。
- (Catalinaでは起こっていないとのことでもあり、)electronにバグレポートするのも大げさな気がする。

electronのTray/Menuには、Menuのpopup状態を取るメソッドはない。
- イベントもコールバックもないため、popupしているか知ること自体が困難。

という状況のため、「状態変化が起こっていない場合、Menuが閉じる原因となる描画更新をスキップする」というパッチを書いてみました。
（状態変化が起こった場合はMenuが閉じてしまいますが、Tray上のアイコン表示があるためそれほど困らず、頻度もそう多くないと考えられる。)