### PR TITLE
startup LaunchAgent

### DIFF
--- a/startup/com.ozonicsky.charger-information-for-mac.plist
+++ b/startup/com.ozonicsky.charger-information-for-mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>KeepAlive</key>
+  <false/>
+  <key>Label</key>
+  <string>com.ozonicsky.charger-information-for-mac</string>
+  <key>Program</key>
+  <string>/Applications/Charger Information.app/Contents/MacOS/Charger Information</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+<string>/tmp/turtle.out</string>
+<key>StandardErrorPath</key>
+<string>/tmp/turtle.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
menuからログイン時に自動起動をON/OFFする機能を追加しました。
実装としてはosxのLaunchAgentsディレクトリに自動起動のファイルを書き出しますが、ON/OFFの判定はファイルの存在チェックではなくStoreのフラグで行なっています。

一つ、懸念事項があります。（別途issueを立てるべきような気がしますがまずこちらでご報告を。）
本アプリがosxの「最近使ったアプリ」に登録されると、本アプリの状態（起動している・いない）に関わらず、アイコンがDockに表示されるようになってしまうようです。
私の環境では本機能の実装中にこの現象が発生するようになり、削除しても次回以降起動するとまた登録が復活する状態です。
本機能自体の問題では無いのですが、実際にスタートアップ起動を運用しているといずれ発生する問題かと思います。
(軽く調べた限りでは、「最近使ったアプリ」（"Recent Applications")はコマンドラインから履歴消去はできるようなのですが、特定のアプリを削除・除外する方法は見つけられませんでした。）